### PR TITLE
Updates `master` for WrenSec repos & info

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-selfservice"
+export BINTRAY_PACKAGE="wrensec-selfservice"
+export JFROG_PACKAGE="org/forgerock/commons"

--- a/forgerock-selfservice-core/pom.xml
+++ b/forgerock-selfservice-core/pom.xml
@@ -13,9 +13,10 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>forgerock-selfservice</artifactId>
@@ -23,11 +24,10 @@
         <version>1.0.3</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>forgerock-selfservice-core</artifactId>
     <packaging>bundle</packaging>
-    <name>Self Service Core</name>
+
+    <name>Wren Security Commons Self Service - Core</name>
     <description>
         Core implementation of the self service framework.
     </description>
@@ -37,14 +37,17 @@
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -55,21 +58,23 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/forgerock-selfservice-custom-stage/pom.xml
+++ b/forgerock-selfservice-custom-stage/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ The contents of this file are subject to the terms of the Common Development and
   ~ Distribution License (the License). You may not use this file except in compliance with the
@@ -14,22 +13,22 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>forgerock-selfservice</artifactId>
         <groupId>org.forgerock.commons</groupId>
         <version>1.0.3</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>forgerock-selfservice-custom-stage</artifactId>
     <packaging>bundle</packaging>
-    <name>A Custom Stage Bundle</name>
-    <description>
-        An example custom stage.
-    </description>
+    
+    <name>Wren Security Commons Self Service - Custom Stage Bundle</name>
+    <description>An example custom stage.</description>
 
     <dependencies>
         <dependency>
@@ -45,6 +44,7 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Fragment-Host>org.forgerock.openidm.selfservice</Fragment-Host>

--- a/forgerock-selfservice-example-ui/pom.xml
+++ b/forgerock-selfservice-example-ui/pom.xml
@@ -3,6 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+  ~ Portions Copyright 2017 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -24,6 +25,7 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>forgerock-selfservice</artifactId>
         <groupId>org.forgerock.commons</groupId>
@@ -31,8 +33,10 @@
     </parent>
 
     <artifactId>forgerock-selfservice-example-ui</artifactId>
-    <name>ForgeRock UI for ForgeRock Self-Service Example</name>
     <packaging>pom</packaging>
+
+    <name>Wren Security Commons Self Service - Example UI</name>
+    <description>UI for Wren Security Self-Service Example</description>
 
     <properties>
         <forgerock-ui.version>8.6.0</forgerock-ui.version>
@@ -44,6 +48,7 @@
                 <directory>${basedir}/src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
+
             <resource>
                 <directory>${basedir}/src/main/js</directory>
                 <filtering>true</filtering>
@@ -55,15 +60,18 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jslint-maven-plugin</artifactId>
                 <version>1.0.1</version>
+
                 <configuration>
                     <excludes>
                         <exclude>**/libs/*.js</exclude>
                         <exclude>**/*Test.js</exclude>
                     </excludes>
                 </configuration>
+
                 <executions>
                     <execution>
                         <phase>validate</phase>
+
                         <goals>
                             <goal>jslint</goal>
                         </goals>
@@ -92,9 +100,11 @@
                     <execution>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
+
                         <goals>
                             <goal>unpack</goal>
                         </goals>
+
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
@@ -107,12 +117,15 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+
                     <execution>
                         <id>copy-dependencies-less</id>
                         <phase>prepare-package</phase>
+
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
+
                         <configuration>
                             <includeArtifactIds>less</includeArtifactIds>
                             <includeTypes>js</includeTypes>
@@ -127,27 +140,34 @@
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>prepare-working-dir</id>
                         <phase>prepare-package</phase>
+
                         <goals>
                             <goal>single</goal>
                         </goals>
+
                         <configuration>
                             <finalName>www</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
+
                             <descriptors>
                                 <descriptor>src/main/assembly/dir.xml</descriptor>
                             </descriptors>
                         </configuration>
                     </execution>
+
                     <execution>
                         <id>build-final-zip</id>
                         <phase>package</phase>
+
                         <goals>
                             <goal>single</goal>
                         </goals>
+
                         <configuration>
                             <descriptors>
                                 <descriptor>src/main/assembly/zip.xml</descriptor>
@@ -160,10 +180,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>compile-structure-less-to-css</id>
                         <phase>prepare-package</phase>
+
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
 
                         <configuration>
                             <target name="compileLess">
@@ -177,33 +202,29 @@
 
                             </target>
                         </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
                     </execution>
+
                     <execution>
                         <id>compile-theme-less-to-css</id>
                         <phase>prepare-package</phase>
 
                         <configuration>
                             <target name="compileLess">
-
                                 <java classname="org.mozilla.javascript.tools.shell.Main" fork="true">
                                     <classpath refid="maven.compile.classpath" />
                                     <arg value="${project.build.directory}/less/less-1.5.1-rhino.js" />
                                     <arg value="${project.build.directory}/www/css/theme.less" />
                                     <arg value="${project.build.directory}/www/css/theme.css" />
                                 </java>
-
                             </target>
                         </configuration>
+
                         <goals>
                             <goal>run</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 
@@ -215,6 +236,7 @@
             <type>zip</type>
             <classifier>www</classifier>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons.ui.libs</groupId>
             <artifactId>less</artifactId>
@@ -222,10 +244,12 @@
             <classifier>rhino</classifier>
             <type>js</type>
         </dependency>
+
         <dependency>
             <groupId>de.matrixweb.osgi.wrapped</groupId>
             <artifactId>osgi-wrapped-rhino</artifactId>
             <version>1.7R4</version>
+
             <exclusions>
                 <exclusion>
                     <groupId>org.mozilla</groupId>

--- a/forgerock-selfservice-example/pom.xml
+++ b/forgerock-selfservice-example/pom.xml
@@ -14,22 +14,22 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>forgerock-selfservice</artifactId>
         <groupId>org.forgerock.commons</groupId>
         <version>1.0.3</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>forgerock-selfservice-example</artifactId>
     <packaging>bundle</packaging>
-    <name>Self Service Examples</name>
-    <description>
-        Some basic self service examples.
-    </description>
+
+    <name>Wren Security Commons Self Service - Examples</name>
+    <description>Some basic self service examples.</description>
 
     <dependencies>
         <dependency>
@@ -37,21 +37,25 @@
             <artifactId>forgerock-selfservice-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-selfservice-custom-stage</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-selfservice-stages</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-selfservice-json</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-selfservice-example-ui</artifactId>
@@ -59,26 +63,32 @@
             <classifier>www</classifier>
             <type>zip</type>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.http</groupId>
             <artifactId>chf-http-servlet</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource-http</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
@@ -90,13 +100,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>war</id>
                         <phase>package</phase>
+
                         <goals>
                             <goal>war</goal>
                         </goals>
+
                         <configuration>
                             <classifier>servlet</classifier>
                         </configuration>
@@ -107,22 +120,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+
                 <executions>
                     <execution>
                     <id>unpack</id>
                     <phase>package</phase>
+
                     <goals>
                         <goal>unpack</goal>
                     </goals>
+
                     <configuration>
                         <artifactItems>
-                        <artifactItem>
-                            <groupId>org.forgerock.commons</groupId>
-                            <artifactId>forgerock-selfservice-example-ui</artifactId>
-                            <version>${project.version}</version>
-                            <type>zip</type>
-                            <classifier>www</classifier>
-                        </artifactItem>
+                            <artifactItem>
+                                <groupId>org.forgerock.commons</groupId>
+                                <artifactId>forgerock-selfservice-example-ui</artifactId>
+                                <version>${project.version}</version>
+                                <type>zip</type>
+                                <classifier>www</classifier>
+                            </artifactItem>
                         </artifactItems>
                         <outputDirectory>${project.build.directory}/webapp</outputDirectory>
                     </configuration>
@@ -134,14 +150,18 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>9.2.1.v20140609</version>
+
                 <configuration>
                     <scanIntervalSeconds>2</scanIntervalSeconds>
+
                     <webApp>
                         <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
                             <resourcesAsCSV>${project.build.directory}/webapp</resourcesAsCSV>
                         </baseResource>
+
                         <contextPath>/example</contextPath>
                     </webApp>
+
                     <httpConnector>
                         <port>9999</port>
                     </httpConnector>
@@ -149,5 +169,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/forgerock-selfservice-json/pom.xml
+++ b/forgerock-selfservice-json/pom.xml
@@ -13,9 +13,10 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>forgerock-selfservice</artifactId>
@@ -23,13 +24,12 @@
         <version>1.0.3</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>forgerock-selfservice-json</artifactId>
     <packaging>bundle</packaging>
-    <name>Self Service Json Config</name>
+
+    <name>Wren Security Commons Self Service - JSON Config</name>
     <description>
-        Json configuration of the self service framework.
+        JSON configuration of the self service framework.
     </description>
 
     <dependencies>
@@ -38,23 +38,28 @@
             <artifactId>forgerock-selfservice-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-selfservice-stages</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -65,16 +70,17 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/forgerock-selfservice-stages/pom.xml
+++ b/forgerock-selfservice-stages/pom.xml
@@ -13,9 +13,10 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>forgerock-selfservice</artifactId>
@@ -23,11 +24,10 @@
         <version>1.0.3</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>forgerock-selfservice-stages</artifactId>
     <packaging>bundle</packaging>
-    <name>Self Service Stages</name>
+
+    <name>Wren Security Commons Self Service - Stages</name>
     <description>
         Implementation of common self service stages.
     </description>
@@ -38,59 +38,69 @@
             <artifactId>forgerock-selfservice-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource-http</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-web-token</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.http</groupId>
             <artifactId>chf-client-apache-sync</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,10 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2016 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.forgerock</groupId>
@@ -23,18 +24,19 @@
         <version>2.0.4</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-selfservice</artifactId>
     <version>1.0.3</version>
     <packaging>pom</packaging>
 
-    <name>Commons Self Service Framework</name>
+    <name>Wren Security Commons Self Service - Framework</name>
     <description>
         Common implementation of self service including such features as password reset and user self service.
     </description>
 
+    <inceptionYear>2017</inceptionYear>
+    <url>https://github.com/WrenSecurity/wrensec-selfservice</url>
+    
     <modules>
         <module>forgerock-selfservice-core</module>
         <module>forgerock-selfservice-custom-stage</module>
@@ -44,16 +46,58 @@
         <module>forgerock-selfservice-stages</module>
     </modules>
 
-    <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-selfservice.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-selfservice.git
-        </developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-selfservice/browse</url>
-      <tag>1.0.3</tag>
-  </scm>
-
     <licenses>
+        <license>
+            <name>CDDL-1.0</name>
+            <url>http://www.opensource.org/licenses/cddl1.php</url>
+
+            <comments>
+                Common Development and Distribution License (CDDL) 1.0.
+                This license applies to Wren Self Service source code as indicated in the
+                source code.
+            </comments>
+
+            <distribution>repo</distribution>
+        </license>
     </licenses>
+
+    <scm>
+        <url>https://github.com/WrenSecurity/wrensec-selfservice</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-selfservice.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-selfservice.git</developerConnection>
+    </scm>
+
+    <repositories>
+        <!-- Needed to retrieve parent POM -->
+        <repository>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <mailingLists>
+        <mailingList>
+            <name>Wren Security Mailing List</name>
+            <archive>https://groups.google.com/forum/#!forum/wren-security</archive>
+            <subscribe>https://groups.google.com/forum/#!forum/wren-security</subscribe>
+            <unsubscribe>https://groups.google.com/forum/#!forum/wren-security</unsubscribe>
+            <post>wren-security@googlegroups.com</post>
+        </mailingList>
+    </mailingLists>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-selfservice/issues</url>
+    </issueManagement>
 
     <properties>
         <commons.forgerock-bom.version>4.1.1</commons.forgerock-bom.version>
@@ -71,11 +115,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.servicemix.bundles</groupId>
                 <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
                 <version>${javax.inject.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
@@ -93,30 +139,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <issueManagement>
-        <system>jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/CSS</url>
-    </issueManagement>
-
-    <repositories>
-        <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION
also cleans-up package names and descriptions to match what we're using in `wrensec-commons` for newer versions of this legacy package.